### PR TITLE
Add missing acme challenge includes

### DIFF
--- a/scripts/deployables/acro-add-website.sh
+++ b/scripts/deployables/acro-add-website.sh
@@ -100,9 +100,9 @@ fi
 
 
 if [ $# -gt 0 ] && (/usr/local/bin/optional-parameter-exists "--skip-ssl" "$@" ||  /usr/local/bin/optional-parameter-exists "--no-ssl" "$@"); then
-  : # SSL has been disabled by request
+  cerr "SSL has been disabled by request"
 elif test -e "$LE_WWW/.well-known/acme-challenge" && test -x "$CERTBOT"; then
-  # Use certbot if it's available
+  cerr "Certbot is available"
   USE_LE=1
   USE_SSL=1
   VHOST_CONF_STUB="-ssl"

--- a/scripts/deployables/apache-vhost-template-d7-conf.j2
+++ b/scripts/deployables/apache-vhost-template-d7-conf.j2
@@ -3,13 +3,14 @@
   DocumentRoot {{ docroot }}
   ErrorLog {{ error_log }}
   CustomLog {{ access_log }} combined
+  Include /etc/apache2/includes/letsencrypt-acme-challenge.conf
   
   <Directory "{{ docroot }}">
     Options -Indexes
     Require all granted
     DirectoryIndex index.php
   </Directory>
-  
+
   <FilesMatch "\.php$">
     SetHandler application/x-httpd-php
   </FilesMatch>

--- a/scripts/deployables/apache-vhost-template-d7-ssl-conf.j2
+++ b/scripts/deployables/apache-vhost-template-d7-ssl-conf.j2
@@ -3,6 +3,7 @@
   DocumentRoot {{ docroot }}
   ErrorLog {{ error_log }}
   CustomLog {{ access_log }} combined
+  Include /etc/apache2/includes/letsencrypt-acme-challenge.conf
   Redirect / https://{{ fqdn }}
 </VirtualHost>
 
@@ -12,22 +13,22 @@
   ErrorLog {{ error_log }}
   CustomLog {{ access_log }} combined
   Include /etc/apache2/includes/letsencrypt-acme-challenge.conf
-  
+
   SSLEngine on
   SSLCertificateFile {{ ssl_cert }}
   SSLCertificateKeyFile {{ ssl_key }}
   SSLCertificateChainFile {{ ssl_ca_bundle }}
   SSLOpenSSLConfCmd DHParameters /usr/local/ssl/private/dhparams.pem
-  
+
   SSLProtocol +TLSv1 +TLSv1.1 +TLSv1.2
   SSLCipherSuite HIGH:!aNULL:!MD5
-  
+
   <Directory "{{ docroot }}">
     Options -Indexes
     Require all granted
     DirectoryIndex index.php
   </Directory>
-  
+
   <FilesMatch "\.php$">
     SetHandler application/x-httpd-php
   </FilesMatch>

--- a/scripts/deployables/nginx-vhost-template-d7-conf.j2
+++ b/scripts/deployables/nginx-vhost-template-d7-conf.j2
@@ -7,6 +7,7 @@ server {
   client_max_body_size 100m;
   access_log {{ access_log }};
   error_log {{ error_log }};
+  include /etc/nginx/includes/letsencrypt-acme-challenge.conf;   # Always include acme challenge, even if the site does not use SSL, so the site *can* switch to ssl if needed.
 
   # Enable compression. This will help if you have, for instance, the advagg module
   # by serving Gzip versions of the files.

--- a/scripts/deployables/nginx-vhost-template-static-conf.j2
+++ b/scripts/deployables/nginx-vhost-template-static-conf.j2
@@ -7,6 +7,7 @@ server {
   client_max_body_size 100m;
   access_log {{ access_log }};
   error_log {{ error_log }};
+  include /etc/nginx/includes/letsencrypt-acme-challenge.conf;   # Always include acme challenge, even if the site does not use SSL, so the site *can* switch to ssl if needed.
 
   # Enable compression. This will help if you have, for instance, the advagg module
   # by serving Gzip versions of the files.


### PR DESCRIPTION
Always include letsencrypt acme challenge conf, even from from non-ssl sites; so the option to register a cert exists

Closes #15 